### PR TITLE
Use SwingUtilities.invokeLater to getDesktop.

### DIFF
--- a/src/application/FXMLMainController.java
+++ b/src/application/FXMLMainController.java
@@ -30,6 +30,8 @@ import application.log.Logger;
 import application.log.Logger.LoggerListener;
 import javafx.stage.Stage;
 
+import javax.swing.*;
+
 public class FXMLMainController implements Initializable {
 
     public static final int TAB_INDEX_APPLICATIONS = 1;
@@ -195,11 +197,15 @@ public class FXMLMainController implements Initializable {
 
     public void onOpenAppDirectory(ActionEvent actionEvent) {
         if (Desktop.isDesktopSupported()) {
-            try {
-                Desktop.getDesktop().open(Preferences.getInstance().getAppFolder());
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
+            SwingUtilities.invokeLater(new Runnable() {
+                public void run() {
+                    try {
+                        Desktop.getDesktop().open(Preferences.getInstance().getAppFolder());
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                    }
+                }
+            });
         }
     }
 

--- a/src/application/screencapture/ScreenCaptureController.java
+++ b/src/application/screencapture/ScreenCaptureController.java
@@ -21,6 +21,7 @@ import javafx.scene.paint.Color;
 import javafx.stage.Stage;
 import javafx.stage.WindowEvent;
 
+import javax.swing.*;
 import java.awt.*;
 import java.io.File;
 import java.io.IOException;
@@ -169,11 +170,15 @@ public class ScreenCaptureController implements Initializable {
 
 	public void onOpenFolderClicked(ActionEvent actionEvent) {
 		if (Desktop.isDesktopSupported()) {
-			try {
-				Desktop.getDesktop().open(new File(Preferences.getInstance().getSnapshotFolder()));
-			} catch (IOException e) {
-				e.printStackTrace();
-			}
+			SwingUtilities.invokeLater(new Runnable() {
+				public void run() {
+					try {
+						Desktop.getDesktop().open(new File(Preferences.getInstance().getSnapshotFolder()));
+					} catch (IOException e) {
+						e.printStackTrace();
+					}
+				}
+			});
 		}
 	}
 


### PR DESCRIPTION
getDesktop will meet the HostServicesFactory ClassNotFoundException
on OpenJdK user. Use SwingUtilities could prevent from this problem
especially for linux+OpenJdk user.

reference:
https://stackoverflow.com/questions/43757614/javafx-and-and-getdesktop-open-crashes-the-program